### PR TITLE
Fix invalid authorization level of Azure Function /api/creategroup which was returning 401

### DIFF
--- a/azure-functions/CreateGroup/function.json
+++ b/azure-functions/CreateGroup/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "authLevel": "function",
+      "authLevel": "Anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",

--- a/azure-functions/CreateOrganization/function.json
+++ b/azure-functions/CreateOrganization/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "authLevel": "anonymous",
+      "authLevel": "Anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177712239